### PR TITLE
チャットに長文が来た時に表示が崩れないように修正

### DIFF
--- a/frontend/src/components/Layout/ContainerItem.tsx
+++ b/frontend/src/components/Layout/ContainerItem.tsx
@@ -9,7 +9,11 @@ export const ContainerItem = ({
 }) => {
     return (
         <>
-            <div style={{ flex: flexRatio, display: "flex" }}>{children}</div>
+            <div
+                style={{ flex: flexRatio, display: "flex", overflow: "hidden" }}
+            >
+                {children}
+            </div>
         </>
     );
 };

--- a/frontend/src/features/chat/ChatHistory.tsx
+++ b/frontend/src/features/chat/ChatHistory.tsx
@@ -22,7 +22,9 @@ export const ChatHistory = ({
         <ContainerCol>
             <ContainerScrollItem>
                 {chatHistMsgs.map((msg, idx) => (
-                    <p key={idx}>{msg}</p>
+                    <p key={idx} style={{ overflowWrap: "break-word" }}>
+                        {msg}
+                    </p>
                 ))}
                 <div ref={scrollBottomRef}></div>
             </ContainerScrollItem>


### PR DESCRIPTION
- 修正前
<img width="1677" alt="before" src="https://user-images.githubusercontent.com/77755127/232973837-6caa52d7-4a64-4d2f-9c02-d56bcdebe1a3.png">

- 修正後
<img width="1676" alt="after" src="https://user-images.githubusercontent.com/77755127/232973861-38eefd37-99a4-4843-9a28-9cef756ab6b4.png">

- ref
  - [overflow-wrap - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/overflow-wrap)
