### PR TITLE
64 testをやりやすくするためにdocker起動時にダミーユーザーをdbに追加した

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -72,5 +72,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/user_seed.ts"
   }
 }

--- a/backend/prisma/user_seed.ts
+++ b/backend/prisma/user_seed.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const user1 = await prisma.user.create({
+    data: {
+      email: 'hoge@test.com',
+      nickname: 'hoge',
+      hashedPassword: 'a',
+    },
+  });
+  const user2 = await prisma.user.create({
+    data: {
+      email: 'hage@test.com',
+      nickname: 'hage',
+      hashedPassword: 'b',
+    },
+  });
+  console.log(user1, user2);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - 5555:5555
     volumes:
       - ./backend:/workdir
-    command: /bin/bash -c "npm install && npx prisma db push --preview-feature && npx prisma generate && npx prisma studio & exec npm run start:dev"
+    command: /bin/bash -c "npm install && npx prisma db push --preview-feature && npx prisma generate && npx prisma db seed && npx prisma studio & exec npm run start:dev"
 
   db:
     build: db

--- a/log/backend-log.md
+++ b/log/backend-log.md
@@ -45,3 +45,8 @@ npm i --save @nestjs/config
 nest g service prisma
 nest g module prisma
 ```
+
+### prisma seed
+```shell
+npx prisma seed
+```[seeding your database](https://www.prisma.io/docs/guides/migrate/seed-database)

--- a/log/backend-log.md
+++ b/log/backend-log.md
@@ -48,5 +48,5 @@ nest g module prisma
 
 ### prisma seed
 ```shell
-npx prisma seed
+npx prisma db seed
 ```[seeding your database](https://www.prisma.io/docs/guides/migrate/seed-database)


### PR DESCRIPTION
”npx prisma db seed”でdbにデータを追加できるようにした。
↑のコマンドでdbに追加できるuserダミーデータを書いた。
docker起動時にdbにuserデータを入れるようにcomposeに↑のコマンドを追記した
参考にしたやつ
https://www.prisma.io/docs/guides/migrate/seed-database