### PR TITLE
&までがバックグランドで実行されていてnpm installが実行されないので&の範囲を狭めた

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - 5555:5555
     volumes:
       - ./backend:/workdir
-    command: /bin/bash -c "npm install && npx prisma db push --preview-feature && npx prisma generate && npx prisma db seed && npx prisma studio & exec npm run start:dev"
+    command: /bin/bash -c "npm install && (npx prisma db push --preview-feature && npx prisma generate && npx prisma db seed && npx prisma studio &) && exec npm run start:dev"
 
   db:
     build: db


### PR DESCRIPTION
npm installがバックグラウンド実行されてたのでprismaの部分のみをバックグランドにした