### PR TITLE
108 post messageエンドポイントのテストを作る

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,6 +24,9 @@ PHONY	+=	fmt-ck
 fmt-ck:
 	npm run format-ck
 
+PHONY += test
+test:
+	npm run test
 # etc...
 # ------------------------------------------------------------------------------------------
 .PHONY: $(PHONY)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
-        "@nestjs/testing": "^9.0.0",
+        "@nestjs/testing": "^9.4.0",
         "@types/express": "^4.17.13",
         "@types/jest": "29.5.0",
         "@types/node": "18.15.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
-    "@nestjs/testing": "^9.0.0",
+    "@nestjs/testing": "^9.4.0",
     "@types/express": "^4.17.13",
     "@types/jest": "29.5.0",
     "@types/node": "18.15.11",

--- a/backend/src/post-message/post-message.service.spec.ts
+++ b/backend/src/post-message/post-message.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostMessageService } from './post-message.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('PostMessageService', () => {
   let service: PostMessageService;

--- a/backend/src/post-message/post-message.service.spec.ts
+++ b/backend/src/post-message/post-message.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PostMessageService } from './post-message.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { PostMessageService } from './post-message.service';
 
 type Message = {
   id: number;

--- a/backend/src/post-message/post-message.service.spec.ts
+++ b/backend/src/post-message/post-message.service.spec.ts
@@ -21,20 +21,34 @@ const mockPrismaService = {
   message: {
     // PrismaService.createをmockMsgを返すだけの関数にした
     create: jest.fn().mockReturnValue(mockMsg),
-  }
+  },
 };
+
 describe('PostMessageService', () => {
   let service: PostMessageService;
-
+  // テスト前の処理をする関数初期化
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PostMessageService],
+      // テスト対象のサービスとその依存してる奴ら
+      providers: [
+        PostMessageService,
+        {
+          // provideをuseValueでmockした
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
     }).compile();
-
     service = module.get<PostMessageService>(PostMessageService);
   });
-
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('post-message', () => {
+    it('should successfully insert a message', () => {
+      expect(
+        service.postMessage({
+          authorId: mockMsg.authorId,
+          content: mockMsg.content,
+        }),
+      ).resolves.toEqual(mockMsg);
+    });
   });
 });

--- a/backend/src/post-message/post-message.service.spec.ts
+++ b/backend/src/post-message/post-message.service.spec.ts
@@ -33,7 +33,7 @@ describe('PostMessageService', () => {
       providers: [
         PostMessageService,
         {
-          // provideをuseValueでmockした
+          // PostMessageServiceのコンストラクターでuseValueのmockPrismaService使う
           provide: PrismaService,
           useValue: mockPrismaService,
         },

--- a/backend/src/post-message/post-message.service.spec.ts
+++ b/backend/src/post-message/post-message.service.spec.ts
@@ -2,6 +2,27 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PostMessageService } from './post-message.service';
 import { PrismaService } from '../prisma/prisma.service';
 
+type Message = {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  content: string;
+  authorId: number;
+};
+const mockMsg: Message = {
+  id: 12,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  content: 'nori',
+  authorId: 1,
+};
+
+const mockPrismaService = {
+  message: {
+    // PrismaService.createをmockMsgを返すだけの関数にした
+    create: jest.fn().mockReturnValue(mockMsg),
+  }
+};
 describe('PostMessageService', () => {
   let service: PostMessageService;
 

--- a/backend/src/post-message/post-message.service.ts
+++ b/backend/src/post-message/post-message.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 import { Message } from '@prisma/client';
 import { MessageDto } from './dto/message.dto';
 

--- a/backend/src/post-message/post-message.service.ts
+++ b/backend/src/post-message/post-message.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
 import { Message } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 import { MessageDto } from './dto/message.dto';
 
 @Injectable()

--- a/log/backend-log.md
+++ b/log/backend-log.md
@@ -69,3 +69,9 @@ npm install --save-dev eslint-plugin-import
 -[nestjs test](https://docs.nestjs.com/fundamentals/testing)
 -[jest mock-fnc](https://jestjs.io/docs/mock-function-api)
 -[nestjs testのサンプル](https://github.com/jmcdo29/testing-nestjs/tree/master)
+
+
+### backend test
+```shell
+make test
+```

--- a/log/backend-log.md
+++ b/log/backend-log.md
@@ -64,3 +64,8 @@ nest g controller user
 ```shell
 npm install --save-dev eslint-plugin-import
 ```
+
+### backendのテスト（jest）
+-[nestjs test](https://docs.nestjs.com/fundamentals/testing)
+-[jest mock-fnc](https://jestjs.io/docs/mock-function-api)
+-[nestjs testのサンプル](https://github.com/jmcdo29/testing-nestjs/tree/master)


### PR DESCRIPTION
jestはテストするファイルのimportを絶対パスで使用するにはpackage.jsonをいじらないといけなさそうなので,相対パスに変更した（問題なければ全部かえる）
`import {UserService} src/user/user.service.ts` -> `import {UserService} ../user/user.service.ts `
post-messageのエンドポイントのmockテスト作成。
dbを操作するPrismaServiceをmockしてるけどdbを使うならテストに変える。

make testでjestを走らせるようにした　