### PR TITLE
111 front import パス の 改善

### DIFF
--- a/frontend/src/features/chat/Chat.tsx
+++ b/frontend/src/features/chat/Chat.tsx
@@ -1,7 +1,7 @@
-import { Container } from '../../components/Layout/Container';
-import { ContainerItem } from '../../components/Layout/ContainerItem';
 import { ChatChannelArea } from './ChatChannelArea';
 import { ChatTalkArea } from './ChatTalkArea';
+import { Container } from '@/components/Layout/Container';
+import { ContainerItem } from '@/components/Layout/ContainerItem';
 
 export const Chat = () => {
   return (

--- a/frontend/src/features/chat/ChatChannelArea.tsx
+++ b/frontend/src/features/chat/ChatChannelArea.tsx
@@ -1,5 +1,5 @@
-import { Container } from '../../components/Layout/Container';
-import { ContainerItem } from '../../components/Layout/ContainerItem';
+import { Container } from '@/components/Layout/Container';
+import { ContainerItem } from '@/components/Layout/ContainerItem';
 
 export const ChatChannelArea = () => {
   const channels: string[] = [];

--- a/frontend/src/features/chat/ChatHistory.tsx
+++ b/frontend/src/features/chat/ChatHistory.tsx
@@ -1,7 +1,6 @@
 import { useLayoutEffect } from 'react';
-
-import { Container } from '../../components/Layout/Container';
-import { ContainerItem } from '../../components/Layout/ContainerItem';
+import { Container } from '@/components/Layout/Container';
+import { ContainerItem } from '@/components/Layout/ContainerItem';
 
 export const ChatHistory = ({
   chatHistMsgs,

--- a/frontend/src/features/chat/ChatInput.tsx
+++ b/frontend/src/features/chat/ChatInput.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
 import { ChangeEvent } from 'react';
 
-import { socket } from '../../socket';
-
-import { Input } from '../../components/Elements/Input/Input';
-import { SendButton } from '../../components/Elements/Button/SendButton';
-
-import { Container } from '../../components/Layout/Container';
 import { postMessage } from './api/postMessage';
+import { socket } from '@/socket';
+import { Input } from '@/components/Elements/Input/Input';
+import { SendButton } from '@/components/Elements/Button/SendButton';
+import { Container } from '@/components/Layout/Container';
 
 export const ChatInput = () => {
   const [msg, setMsg] = useState('');

--- a/frontend/src/features/chat/ChatTalkArea.tsx
+++ b/frontend/src/features/chat/ChatTalkArea.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 
-import { socket } from '../../socket';
-
-import { Container } from '../../components/Layout/Container';
-
 import { ChatHistory } from './ChatHistory';
 import { ChatInput } from './ChatInput';
 import { ChatTalkAreaHeader } from './ChatTalkAreaHeader';
+import { Container } from '@/components/Layout/Container';
+import { socket } from '@/socket';
 
 const isScrollBottom = (scrollBottomRef: React.RefObject<HTMLDivElement>) => {
   const scrollParentElement = scrollBottomRef?.current?.parentElement;

--- a/frontend/src/features/chat/ChatTalkAreaHeader.tsx
+++ b/frontend/src/features/chat/ChatTalkAreaHeader.tsx
@@ -1,6 +1,6 @@
-import { Container } from '../../components/Layout/Container';
-import { socket } from '../../socket';
-import { BasicButton } from '../../components/Elements/Button/BasicButton';
+import { Container } from '@/components/Layout/Container';
+import { socket } from '@/socket';
+import { BasicButton } from '@/components/Elements/Button/BasicButton';
 
 const onGetChatLogAct = () => {
   console.log('OnGetChatLogButton');

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
       typescript: true,
     }),
   ],
+  resolve: {
+    alias: [{ find: '@', replacement: '/src' }],
+  },
 });

--- a/log/frontend-log.md
+++ b/log/frontend-log.md
@@ -8,6 +8,9 @@ npm create vite@latest . -- --template react-ts
 
 - config
   - [サーバオプション | Vite](https://ja.vitejs.dev/config/server-options.html)
+- import alias
+  - [共通オプション | Vite](https://ja.vitejs.dev/config/shared-options.html)
+  - [Vite+React+TypeScript+EsLint で、Import パスにエイリアスを使うためにハマったこと](https://zenn.dev/longbridge/articles/5e33ff1a625158)
 
 ## prettier, eslint
 


### PR DESCRIPTION
- import で alias を使用して import できるようにした
  - `import { Container } from '../../components/Layout/Container';` 
  - ->
  - `import { Container } from '@/components/Layout/Container';`
- 下記 記事 などで `eslint-import-resolver-typescript` が紹介されてたが
- 特にメリットもよくわからんかったし、今回は特に問題出てないので一旦無視
  - [Vite+React+TypeScript+EsLintで、Importパスにエイリアスを使うためにハマったこと](https://zenn.dev/longbridge/articles/5e33ff1a625158)
  - よくわからんし、問題ないので放置
    - [TypeScript / JavaScript の import を自動でソートする - Sansan Tech Blog](https://buildersbox.corp-sansan.com/entry/2021/05/28/110000)
