### PR TITLE
115 GitHub action の キャッシュを 修正

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -23,7 +23,12 @@ jobs:
           path: backend/node_modules
           key: cache-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
 
+      - name: frontend npm install
+        run: cd frontend && npm install
       - name: frontend fmt-ck
-        run: cd frontend && npm install && make fmt-ck
+        run: cd frontend && timeout 300 make fmt-ck
+
+      - name: backend npm install
+        run: cd backend && npm install
       - name: backend fmt-ck
-        run: cd backend && npm install && make fmt-ck
+        run: cd backend && timeout 300 make fmt-ck

--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
       - name: frontend fmt-ck
         run: cd frontend && npm install && make fmt-ck
       - name: backend fmt-ck

--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -8,6 +8,21 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
+
+      - name: cache frontend node-modules
+        id: cache-frontend-node-modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: cache-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: cache backend node-modules
+        id: cache-backend-node-modules
+        uses: actions/cache@v3
+        with:
+          path: backend/node_modules
+          key: cache-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+
       - name: frontend fmt-ck
         run: cd frontend && npm install && make fmt-ck
       - name: backend fmt-ck

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -8,6 +8,21 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
+
+      - name: cache frontend node-modules
+        id: cache-frontend-node-modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: cache-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: cache backend node-modules
+        id: cache-backend-node-modules
+        uses: actions/cache@v3
+        with:
+          path: backend/node_modules
+          key: cache-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+
       - name: frontend lint
         run: cd frontend && npm install && timeout 300 make lint
       - name: backend lint

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
       - name: frontend lint
         run: cd frontend && npm install && timeout 300 make lint
       - name: backend lint

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -23,7 +23,12 @@ jobs:
           path: backend/node_modules
           key: cache-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
 
+      - name: frontend npm install
+        run: cd frontend && npm install
       - name: frontend lint
-        run: cd frontend && npm install && timeout 300 make lint
+        run: cd frontend && timeout 300 make lint
+
+      - name: backend npm install
+        run: cd backend && npm install
       - name: backend lint
-        run: cd backend  && npm install && timeout 300 make lint
+        run: cd backend && timeout 300 make lint

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -9,12 +9,6 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
       - name: install playwright
         run: npx playwright install && npx playwright install-deps
       - name: run storybook test

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -9,6 +9,14 @@ jobs:
     steps:
       - name: checkout git repository
         uses: actions/checkout@v3
+
+      - name: cache frontend node-modules
+        id: cache-frontend-node-modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: cache-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
       - name: install playwright
         run: npx playwright install && npx playwright install-deps
       - name: run storybook test


### PR DESCRIPTION
- frontend, backend の node_modules を キャッシュ化
- プルリク ごとには install が走る
  - `restore-keys` を 設定すれば 走らないようになる？
  - まだ勉強中、とりあえず これで問題なく動く
- このブランチで実験
- リンク先の ✅ とか ❌ から それぞれの ワークフローにかかってる時間見れるマス
  - https://github.com/s-xix98/trc-prot/pull/117/commits
    - [他のブランチからでも キャッシュが有効に使えているかのテストます](https://github.com/s-xix98/trc-prot/pull/117/commits/64e9b8021681aa49177281abc3b6184c427b2d36) -> 新しいプルリクだと時間かかる
    - [他のブランチからの時はキャッシュが効いてない感じ？](https://github.com/s-xix98/trc-prot/pull/117/commits/623ec023f288e096c1a989bf985df560a5fa8776) -> キャッシュで インストールが早い
    - [ハッシュが 変わって フロント は 再インストールされるはず](https://github.com/s-xix98/trc-prot/pull/117/commits/36299a860faf0100be953d7022b872642ab151c0) -> key に 使ってるハッシュ変わって再インストール

ref

- [依存関係をキャッシュしてワークフローのスピードを上げる - GitHub Docs](https://docs.github.com/ja/actions/using-workflows/caching-dependencies-to-speed-up-workflows)

---

今回試してないけど、こいつらとかも 使えるかも？ 勉強中ます

- `actions/setup-node@v3` とか使えば簡単にできる？
- `npm ci` とかいうやつもあるらしい
  - [npm install と npm ci って結局どう使うの？2023 年版 - Mitsuyuki.Shiiba](https://bufferings.hatenablog.com/entry/2023/03/15/215044)
