### PR TITLE
132 login成功時、signup成功時にuserの情報を返すようにした

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -8,8 +8,8 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post('signup')
-  signUp(@Body() dto: signUpDto) {
-    this.userService.signUp(dto);
+  async signUp(@Body() dto: signUpDto): Promise<User> {
+    return this.userService.signUp(dto);
   }
 
   @HttpCode(HttpStatus.OK)

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,8 +1,9 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { User } from '@prisma/client';
 
 import { loginDto, signUpDto } from './dto/user.dto';
 import { UserService } from './user.service';
-import { User } from '@prisma/client';
+
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,8 +1,8 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 
 import { loginDto, signUpDto } from './dto/user.dto';
 import { UserService } from './user.service';
-
+import { User } from '@prisma/client';
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -11,8 +11,10 @@ export class UserController {
   signUp(@Body() dto: signUpDto) {
     this.userService.signUp(dto);
   }
+
+  @HttpCode(HttpStatus.OK)
   @Post('login')
-  login(@Body() dto: loginDto) {
-    this.userService.login(dto);
+  async login(@Body() dto: loginDto): Promise<User> {
+    return this.userService.login(dto);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,4 +1,3 @@
-
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { User } from '@prisma/client';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
@@ -15,7 +14,7 @@ export class UserController {
   @ApiOperation({ summary: 'signUp nori' })
   async signUp(@Body() dto: signUpDto): Promise<User> {
     return this.userService.signUp(dto);
-}
+  }
 
   @HttpCode(HttpStatus.OK)
   @Post('login')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -43,12 +43,12 @@ export class UserService {
     if (!user) {
       console.log('emailが間違っている');
       throw new ForbiddenException('Email incorrect');
-    } else if (user.hashedPassword != dto.hashedPassword) {
+    }
+    if (user.hashedPassword != dto.hashedPassword) {
       console.log('passwordが間違っている');
       throw new ForbiddenException('Password incorrect');
-    } else {
-      console.log('OK');
     }
+    console.log('OK');
     return user;
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,8 +1,9 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
-import { loginDto, signUpDto } from './dto/user.dto';
 import { Prisma } from '@prisma/client';
+
+import { loginDto, signUpDto } from './dto/user.dto';
 @Injectable()
 export class UserService {
   constructor(private prisma: PrismaService) {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-
+import { User } from '@prisma/client';
 import { loginDto, signUpDto } from './dto/user.dto';
 @Injectable()
 export class UserService {
@@ -27,7 +27,7 @@ export class UserService {
       });
   }
 
-  async login(dto: loginDto) {
+  async login(dto: loginDto): Promise<User> {
     console.log(dto);
     const user = await this.prisma.user.findUnique({
       where: {
@@ -36,10 +36,13 @@ export class UserService {
     });
     if (!user) {
       console.log('emailが間違っている');
+      throw new ForbiddenException('Email incorrect');
     } else if (user.hashedPassword != dto.hashedPassword) {
       console.log('passwordが間違っている');
+      throw new ForbiddenException('Password incorrect');
     } else {
       console.log('OK');
     }
+    return user;
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -2,6 +2,7 @@ import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
 import { loginDto, signUpDto } from './dto/user.dto';
+import { Prisma } from '@prisma/client';
 @Injectable()
 export class UserService {
   constructor(private prisma: PrismaService) {}
@@ -20,6 +21,12 @@ export class UserService {
       return user;
     } catch (e) {
       console.log(e);
+      // email,nicknameが被った時のエラーは'P2002'が帰ってくる
+      if (e instanceof Prisma.PrismaClientKnownRequestError) {
+        if (e.code === 'P2002') {
+          throw new ForbiddenException('Email or nickname is already taken');
+        }
+      }
       // 500 internal server err
       throw e;
     }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -6,25 +6,23 @@ import { loginDto, signUpDto } from './dto/user.dto';
 export class UserService {
   constructor(private prisma: PrismaService) {}
 
-  async signUp(dto: signUpDto) {
-    // エラー処理は書いてない
+  async signUp(dto: signUpDto): Promise<User> {
     console.log(dto);
-    const user = this.prisma.user.create({
-      data: {
-        email: dto.email,
-        nickname: dto.nickname,
-        // 今後ハッシュ化
-        hashedPassword: dto.hashedPassword,
-      },
-    });
-    user
-      .then((e) => {
-        console.log(e);
-      })
-      .catch((e) => {
-        // emailが被った時のエラーは'P2002'が帰ってくる
-        console.log(e);
+    try {
+      const user = await this.prisma.user.create({
+        data: {
+          email: dto.email,
+          nickname: dto.nickname,
+          // 今後ハッシュ化
+          hashedPassword: dto.hashedPassword,
+        },
       });
+      return user;
+    } catch (e) {
+      console.log(e);
+      // 500 internal server err
+      throw e;
+    }
   }
 
   async login(dto: loginDto): Promise<User> {


### PR DESCRIPTION
ユーザーの入力でlogin,signup失敗時のエラーコードは403にした
他のエラーはデフォルトで５００。
https://docs.nestjs.com/exception-filters

login成功時は200を返すようにした

P2002
https://www.prisma.io/docs/reference/api-reference/error-reference
