### PR TITLE
135 node modules を docker コンテナ に

### DIFF
--- a/backend/.devcontainer.json
+++ b/backend/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "backend",
+  "workspaceFolder": "/workdir",
+  "shutdownAction": "none"
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,7 @@
 FROM node
 
 WORKDIR /workdir
+
+COPY --chown=node:node package*.json ./
+
+RUN npm i

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 version: '3'
+
+volumes:
+  frontend_node_modules:
+  backend_node_modules:
+
 services:
   frontend:
     build: frontend
@@ -8,6 +13,7 @@ services:
       - 6006:6006
     volumes:
       - ./frontend:/workdir
+      - frontend_node_modules:/workdir/node_modules
     command: /bin/bash -c "npm install && exec npm run concurrent"
 
   backend:
@@ -20,6 +26,7 @@ services:
       - 5555:5555
     volumes:
       - ./backend:/workdir
+      - backend_node_modules:/workdir/node_modules
     command: /bin/bash -c "npm install && (npx prisma db push --preview-feature && npx prisma generate && npx prisma db seed && npx prisma studio &) && exec npm run start:dev"
 
   db:

--- a/frontend/.devcontainer.json
+++ b/frontend/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "frontend",
+  "workspaceFolder": "/workdir",
+  "shutdownAction": "none"
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,9 @@
 FROM node
 
-RUN npx playwright install && npx playwright install-deps
-
 WORKDIR /workdir
+
+COPY --chown=node:node package*.json ./
+
+RUN npm i
+
+RUN npx playwright install && npx playwright install-deps


### PR DESCRIPTION
- node_modules を docker コンテナ内に インストール
- とりあえず 下の記事読んで
  - [VSCode&Docker Volumeにおけるnode_modules問題を解決する](https://zenn.dev/yumemi_inc/articles/3d327557af3554)
- node_modules ディレクトリのみ コンテナと 同期しない
- また docker ビルド時に npm i するようにしたので、再ビルドする時 時間かかる時あるかも。
- node_modules を ホスト側に なくても 動くが、vscode が node_modules を 参照できずに エラーとか出る
  - ローカルでも front, back で `npm i` する 
  or 
  - vscode の devcontainer 使う
    - 一応 設定したが、front, back が あるので 正直 あんまり使いやすくないかも。
    - [Connect to multiple containers](https://code.visualstudio.com/remote/advancedcontainers/connect-multiple-containers)
