### PR TITLE
ContainerItem css display の デフォルト を inline に 設定

### DIFF
--- a/frontend/src/components/Layout/ContainerItem.tsx
+++ b/frontend/src/components/Layout/ContainerItem.tsx
@@ -2,13 +2,13 @@ import { ReactNode } from 'react';
 
 export const ContainerItem = ({
   children,
-  display = 'auto',
+  display = 'inline',
   flexRatio = 1,
   overflowX = 'hidden',
   overflowY = 'hidden',
 }: {
   children: ReactNode;
-  display?: 'auto' | 'flex';
+  display?: 'inline' | 'flex';
   flexRatio?: number;
   overflowX?: 'hidden' | 'scroll';
   overflowY?: 'hidden' | 'scroll';


### PR DESCRIPTION
- ContainerItem css display の デフォルト を inline に 設定
- 元の auto なんて パラメータは 存在しなかったようだ ( ; ; )
