### PR TITLE
154 backendのテストが依存関係やimportパスでfailしてるから修正する

### DIFF
--- a/backend/src/events/events.gateway.spec.ts
+++ b/backend/src/events/events.gateway.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TestModule } from '../test/test.module';
+
 import { EventsGateway } from './events.gateway';
 
 describe('EventsGateway', () => {
@@ -7,6 +9,7 @@ describe('EventsGateway', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
       providers: [EventsGateway],
     }).compile();
 

--- a/backend/src/events/events.gateway.ts
+++ b/backend/src/events/events.gateway.ts
@@ -1,6 +1,7 @@
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
-import { PrismaService } from 'src/prisma/prisma.service';
+
+import { PrismaService } from '../prisma/prisma.service';
 
 @WebSocketGateway({
   cors: {

--- a/backend/src/post-message/post-message.controller.spec.ts
+++ b/backend/src/post-message/post-message.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TestModule } from '../test/test.module';
+
 import { PostMessageController } from './post-message.controller';
 
 describe('PostMessageController', () => {
@@ -7,6 +9,7 @@ describe('PostMessageController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
       controllers: [PostMessageController],
     }).compile();
 

--- a/backend/src/post-message/post-message.controller.spec.ts
+++ b/backend/src/post-message/post-message.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TestModule } from '../test/test.module';
 
 import { PostMessageController } from './post-message.controller';
+import { PostMessageService } from './post-message.service';
 
 describe('PostMessageController', () => {
   let controller: PostMessageController;
@@ -11,6 +12,7 @@ describe('PostMessageController', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [TestModule],
       controllers: [PostMessageController],
+      providers: [PostMessageService],
     }).compile();
 
     controller = module.get<PostMessageController>(PostMessageController);

--- a/backend/src/prisma/prisma.service.spec.ts
+++ b/backend/src/prisma/prisma.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TestModule } from '../test/test.module';
+
 import { PrismaService } from './prisma.service';
 
 describe('PrismaService', () => {
@@ -7,6 +9,7 @@ describe('PrismaService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
       providers: [PrismaService],
     }).compile();
 

--- a/backend/src/test/test.module.ts
+++ b/backend/src/test/test.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+import { PrismaModule } from '../prisma/prisma.module';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  imports: [PrismaModule, ConfigModule],
+  providers: [PrismaService, ConfigService],
+  exports: [PrismaService, ConfigService],
+})
+export class TestModule {}

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TestModule } from '../test/test.module';
 
 import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -11,6 +12,7 @@ describe('UserController', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [TestModule],
       controllers: [UserController],
+      providers: [UserService],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TestModule } from '../test/test.module';
+
 import { UserController } from './user.controller';
 
 describe('UserController', () => {
@@ -7,6 +9,7 @@ describe('UserController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
       controllers: [UserController],
     }).compile();
 

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TestModule } from '../test/test.module';
+
 import { UserService } from './user.service';
 
 describe('UserService', () => {
@@ -7,6 +9,7 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
       providers: [UserService],
     }).compile();
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,7 +1,8 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
 import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service';
 
 import { loginDto, signUpDto } from './dto/user.dto';
 @Injectable()


### PR DESCRIPTION
同じ入力を何度もしないために、全てのテストファイルに依存しているproviderをexportするだけのTestmoduleを作った.

依存関係やimoprtのパスでエラーが出てたから修正した

追記
import { PrismaService } from 'src/prisma/prisma.service';
↓に変更
import { PrismaService } from '../prisma/prisma.service';

#154　をした
cd backend && make test　で確認できる