### PR TITLE
main に 変更が あった際に 再度 github action が 実行されるようにした

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,7 +1,14 @@
 # This is a github action to check if a build can be done.
 
 name: check-build
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   make-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -1,7 +1,14 @@
 # This is a github action to check if the code style is correct.
 
 name: check-code-style
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   make-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,7 +1,14 @@
 # This is a github action to check for errors in linter.
 
 name: check-lint
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   make-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -12,7 +12,14 @@
 #   - https://playwright.dev/docs/ci
 
 name: storybook-test
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   storybook-test:
     timeout-minutes: 5


### PR DESCRIPTION
- github action の on に main push を 追加
- main に 変更があるたびに 再実行されるようになったはず

- ref
  - [スクリプトを使ってランナーでコードをテストする - GitHub Docs](https://docs.github.com/ja/actions/examples/using-scripts-to-test-your-code-on-a-runner)
