### PR TITLE
DATABASE_URL を 実行環境によって 変わるようにした

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,4 +4,10 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://test:test@db:5432/test?schema=public"
+# - docker-compose で 起動される際は、docker-compose.yml で 環境変数を設定している
+# - すでに 定義 されている 環境変数があれば、そちらが 優先される
+# - [Configuration | NestJS - A progressive Node.js framework](https://docs.nestjs.com/techniques/configuration)
+#   > When a key exists both in the runtime environment as an environment variable 
+#   > (e.g., via OS shell exports like export DATABASE_USER=test) and in a .env file, the runtime environment variable takes precedence.
+
+DATABASE_URL="postgresql://test:test@localhost:5432/test?schema=public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     volumes:
       - ./backend:/workdir
       - backend_node_modules:/workdir/node_modules
+    environment:
+      - DATABASE_URL=postgresql://test:test@db:5432/test?schema=public
     command: /bin/bash -c "npm install && (npx prisma db push --preview-feature && npx prisma generate && npx prisma db seed && npx prisma studio &) && exec npm run start:dev"
 
   db:


### PR DESCRIPTION
- とりあえず、docker compose で起動された場合と そうでない場合で分岐
- そもそも、`.env` を git 管理してるのも よくないから ファイル名変えたりするます
  - #183 イシュー立てたます

