### PR TITLE
backende-testを他のciと同じタイミングで発火するようにした

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,5 +1,11 @@
 name: backend-test
-on: [pull_request, workflow_dispatch]
+on:
+    push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   make-backend-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`on:
    push:
    branches:
      - main
  pull_request:
  workflow_dispatch:`
  パクりましたまする