### PR TITLE
ciのcheck-buildでPrismaClientを生成するコマンドを追加した

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -38,4 +38,4 @@ jobs:
       - name: backend npm install
         run: cd backend && npm install
       - name: backend build
-        run: cd backend && timeout 300 make build
+        run: cd backend && npx prisma generate && timeout 300 make build


### PR DESCRIPTION
PrismaClientのメソッドがないとbuild時にエラーが出る。
ciのcheck-buildで現在のスキーマに合わせてPrismaClientを生成するようにした。
