### PR TITLE
storybookの出力が大量に出ているのを、あまり出ないように

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "lint": "npm run next-lint && eslint --max-warnings=0 src",
     "lint-fix": "eslint --fix src",
     "noEmit": "tsc --noEmit",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --quiet",
     "storybook-test": "test-storybook",
     "storybook-test-ci": "concurrently --kill-others --success first \"npm run storybook\" \"wait-on tcp:6006 && npm run storybook-test\"",
     "storybook-update-snapshot": "test-storybook --updateSnapshot",


### PR DESCRIPTION
- storybookの出力が大量に出ているので、`--quiet` オプションをつけて、あまり出ないようにした
- 参考リンク
  - [CLI options](https://storybook.js.org/docs/react/api/cli-options)
