### PR TITLE
playwright install-deps は毎回実行するようにした

### DIFF
--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -76,7 +76,9 @@ jobs:
         run: cd frontend && npm install
       - if: ${{ steps.cache-playwright.outputs.cache-hit != 'true' }}
         name: install playwright
-        run: cd frontend && npx playwright install --with-deps
+        run: cd frontend && npx playwright install
+      - name: install playwright deps
+        run: cd frontend && npx playwright install-deps
       - name: is storybook file exists
         run: cd frontend && make sb-ck-file
       - name: run storybook test


### PR DESCRIPTION
- ci で cache している ディレクトリは `~/.cache/ms-playwright` だけ
- `npx playwright install-deps` で インストールされるものは、この場所以外にインストールされてる
- 上記のため、毎回 `npx playwright install-deps` を実行するようにした
