### PR TITLE
next js で ホットリロードが効くように

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     ports:
       - 3000:3000
       - 6006:6006
+    environment:
+      - WATCHPACK_POLLING=true
     volumes:
       - ./frontend:/workdir
       - frontend_node_modules:/workdir/node_modules


### PR DESCRIPTION
- next js で ホットリロードが効くように
- 環境変数 WATCHPACK_POLLING を true に設定

- パッとリファレンス見つけられなかったます
  - 多分 watchpack の WATCHPACK_POLLING を同じ
  - [watchpack/README.md at main · webpack/watchpack · GitHub](https://github.com/webpack/watchpack/blob/main/README.md)

- 参考にした記事
  - [next.js の開発環境を Docker で構築しようとした時にハマったことまとめ | 経験知](https://keikenchi.com/build-nextjs-development-environment-with-docker)
