### PR TITLE
42auth-login-エンドポイントを作成する 分割します

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^2.3.1",
         "@nestjs/core": "^9.0.0",
+        "@nestjs/jwt": "^10.0.3",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/platform-socket.io": "^9.4.0",
         "@nestjs/swagger": "^6.3.0",
@@ -1496,6 +1497,18 @@
         }
       }
     },
+    "node_modules/@nestjs/jwt": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-10.0.3.tgz",
+      "integrity": "sha512-WO8MI3uEMOFKpbO+SAg6l4aRCr+9KvaL+raFMZaXuEUDphXek6pqdox+4tex9242pNSJUA0trfAMaiy/yVrXQg==",
+      "dependencies": {
+        "@types/jsonwebtoken": "9.0.1",
+        "jsonwebtoken": "9.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz",
@@ -2029,6 +2042,14 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -3035,6 +3056,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3614,6 +3640,14 @@
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -6297,6 +6331,40 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -7718,7 +7786,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
       "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7733,7 +7800,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7744,8 +7810,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/jwt": "^10.0.3",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/platform-socket.io": "^9.4.0",
     "@nestjs/swagger": "^6.3.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,7 +15,7 @@ model User {
   id             String          @id @default(cuid())
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
-  username       String          @unique
+  username       String          @unique @default(uuid())
   email          String          @unique
   hashedPassword String
   messages       Message[]

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,11 +28,12 @@ model User {
 }
 
 model Auth {
-  userId String @unique
-  providerId String
+  userId       String       @unique
+  providerId   String
   providerName String
   authProvider AuthProvider @relation(fields: [providerName], references: [name])
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   @@unique([providerName, providerId])
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,6 +24,21 @@ model User {
   userProfile    UserProfile?
   friendship1    Friendship[]    @relation("src")
   friendship2    Friendship[]    @relation("dest")
+  auth           Auth?
+}
+
+model Auth {
+  userId String @unique
+  providerId String
+  providerName String
+  authProvider AuthProvider @relation(fields: [providerName], references: [name])
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@unique([providerName, providerId])
+}
+
+model AuthProvider {
+  name String @unique
+  auth Auth[]
 }
 
 // 今のところ画像のみ

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,15 @@ import { UserRole } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
+  const authProvider = await prisma.authProvider.upsert({
+    where: {
+      name: '42',
+    },
+    update: {},
+    create: {
+      name: '42',
+    },
+  });
   const user1 = await prisma.user.upsert({
     where: {
       email: 'huga@example.com',
@@ -57,6 +66,8 @@ async function main() {
       chatRoomId: room.id,
     },
   });
+
+  console.log(authProvider);
   console.log(user1, user2);
   console.log(room, roomMember1, roomMember2);
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { PostMessageModule } from './post-message/post-message.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
 import { ChatModule } from './chat/chat.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ChatModule } from './chat/chat.module';
     ConfigModule,
     UserModule,
     ChatModule,
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService, EventsGateway],

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TestModule } from '../test/test.module';
+
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  test('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,16 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
 
 import { TestModule } from '../test/test.module';
 
 import { AuthController } from './auth.controller';
-
+import { AuthModule } from './auth.module';
+import { AuthService } from './auth.service';
 describe('AuthController', () => {
   let controller: AuthController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [TestModule],
+      imports: [TestModule, AuthModule],
       controllers: [AuthController],
+      providers: [AuthService, JwtService],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('auth')
+export class AuthController {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,17 +1,18 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
 import { AuthService } from './auth.service';
 import { accessToken } from './types/auth.types';
 import { authLoginDto } from './dto/auth.dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
 @Controller('auth')
 @ApiTags('/auth')
 export class AuthController {
-  constructor(private readonly authService :AuthService) {}
+  constructor(private readonly authService: AuthService) {}
 
   @HttpCode(HttpStatus.OK)
   @Post('42login')
   @ApiOperation({ summary: '42login' })
-  async ftLogin(@Body() dto: authLoginDto):Promise<accessToken> {
+  async ftLogin(@Body() dto: authLoginDto): Promise<accessToken> {
     return this.authService.ftLogin(dto);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,12 @@
-import { Controller } from '@nestjs/common';
-
+import { Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
 @Controller('auth')
-export class AuthController {}
+export class AuthController {
+  constructor(private readonly authService :AuthService) {}
+
+  @HttpCode(HttpStatus.OK)
+  @Post('42login')
+  async ftLogin() {
+    return this.authService.ftLogin();
+  }
+}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,13 +1,14 @@
-import { Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { accessToken } from './types/auth.types';
+import { authLoginDto } from './dto/auth.dto';
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService :AuthService) {}
 
   @HttpCode(HttpStatus.OK)
   @Post('42login')
-  async ftLogin():Promise<accessToken> {
-    return this.authService.ftLogin();
+  async ftLogin(@Body() dto: authLoginDto):Promise<accessToken> {
+    return this.authService.ftLogin(dto);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,12 +2,15 @@ import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { accessToken } from './types/auth.types';
 import { authLoginDto } from './dto/auth.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 @Controller('auth')
+@ApiTags('/auth')
 export class AuthController {
   constructor(private readonly authService :AuthService) {}
 
   @HttpCode(HttpStatus.OK)
   @Post('42login')
+  @ApiOperation({ summary: '42login' })
   async ftLogin(@Body() dto: authLoginDto):Promise<accessToken> {
     return this.authService.ftLogin(dto);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { accessToken } from './types/auth.types';
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService :AuthService) {}
 
   @HttpCode(HttpStatus.OK)
   @Post('42login')
-  async ftLogin() {
+  async ftLogin():Promise<accessToken> {
     return this.authService.ftLogin();
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -4,8 +4,10 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import {JwtModule} from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { PrismaModule } from '../prisma/prisma.module';
 @Module({
   imports: [
+    PrismaModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,8 +2,19 @@ import { Module } from '@nestjs/common';
 
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-
+import {JwtModule} from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 @Module({
+  imports: [
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET') || '',
+      }),
+    }),
+  ],
   controllers: [AuthController],
   providers: [AuthService],
 })

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-
-import { AuthService } from './auth.service';
-import { AuthController } from './auth.controller';
-import {JwtModule} from '@nestjs/jwt';
+import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+
 import { PrismaModule } from '../prisma/prisma.module';
+
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 @Module({
   imports: [
     PrismaModule,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TestModule } from '../test/test.module';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  test('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,16 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
 
 import { TestModule } from '../test/test.module';
 
 import { AuthService } from './auth.service';
+import { AuthModule } from './auth.module';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [TestModule],
-      providers: [AuthService],
+      imports: [TestModule, AuthModule],
+      providers: [AuthService, JwtService],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,9 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  ftLogin() {
+    const mockJwt = 'mockJwt';
+    return mockJwt;
+  }
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -19,6 +19,6 @@ export class AuthService {
       id,
       username,
     };
-    return this.jwtService.signAsync(payload);
+    return this.jwtService.signAsync(payload, { expiresIn: '1h' });
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,9 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { accessToken } from './types/auth.types';
+import { JwtService } from '@nestjs/jwt';
 @Injectable()
 export class AuthService {
-  ftLogin(): accessToken {
-    const mockJwt = 'mockJwt';
-    return { jwt: mockJwt };
+  constructor(private readonly jwtService: JwtService) {}
+
+  async ftLogin(): Promise<accessToken> {
+    const mockUserData = {
+      id: 'mockId',
+      username: 'mockUsername',
+    };
+
+    return { jwt: await this.generateJwt(mockUserData.id, mockUserData.username)};
+  }
+
+  async generateJwt(id: string, username: string): Promise<string> {
+    const payload = {
+      id,
+      username,
+    };
+    return this.jwtService.signAsync(payload);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -16,6 +16,20 @@ export class AuthService {
       providerName: '42',
     };
 
+    const authUser = await this.prismaService.auth.findUnique({
+      include: { user: true },
+      where: {
+        providerName_providerId: {
+          providerId: mockAuthLoginDto.providerId,
+          providerName: mockAuthLoginDto.providerName,
+        },
+      },
+    });
+
+    if (authUser) {
+      return { jwt: await this.generateJwt(authUser.userId, authUser.user.username)};
+    }
+
     const createdUser = await this.prismaService.user.create({
       include: { auth: true },
       data: {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,17 +1,37 @@
 import { Injectable } from '@nestjs/common';
 import { accessToken } from './types/auth.types';
 import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma/prisma.service';
 @Injectable()
 export class AuthService {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(private readonly jwtService: JwtService, private readonly prismaService:PrismaService) {}
 
   async ftLogin(): Promise<accessToken> {
-    const mockUserData = {
-      id: 'mockId',
-      username: 'mockUsername',
+
+    const mockAuthLoginDto = {
+      email: 'mockEmail@example.com',
+      mockUsername: 'mockUsername',
+      mockHashedPassword: 'mockHashedPassword',
+      providerId: 'mockSub',
+      providerName: '42',
     };
 
-    return { jwt: await this.generateJwt(mockUserData.id, mockUserData.username)};
+    const createdUser = await this.prismaService.user.create({
+      include: { auth: true },
+      data: {
+        email: mockAuthLoginDto.email,
+        username: mockAuthLoginDto.mockUsername,
+        // TODO hashedPassword? にしたら消す
+        hashedPassword: mockAuthLoginDto.mockHashedPassword,
+        auth: {
+          create: {
+            providerId: mockAuthLoginDto.providerId,
+            providerName: mockAuthLoginDto.providerName,
+          },
+        },
+      },
+    });
+    return { jwt: await this.generateJwt(createdUser.id, createdUser.username)};
   }
 
   async generateJwt(id: string, username: string): Promise<string> {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -10,7 +10,6 @@ export class AuthService {
 
     const mockAuthLoginDto = {
       email: 'mockEmail@example.com',
-      mockUsername: 'mockUsername',
       mockHashedPassword: 'mockHashedPassword',
       providerId: 'mockSub',
       providerName: '42',
@@ -34,7 +33,6 @@ export class AuthService {
       include: { auth: true },
       data: {
         email: mockAuthLoginDto.email,
-        username: mockAuthLoginDto.mockUsername,
         // TODO hashedPassword? にしたら消す
         hashedPassword: mockAuthLoginDto.mockHashedPassword,
         auth: {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,14 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { accessToken } from './types/auth.types';
 import { JwtService } from '@nestjs/jwt';
 
 import { PrismaService } from '../prisma/prisma.service';
 
+import { accessToken } from './types/auth.types';
 import { authLoginDto } from './dto/auth.dto';
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly jwtService: JwtService, private readonly prismaService:PrismaService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly prismaService: PrismaService,
+  ) {}
 
   async ftLogin(dto: authLoginDto): Promise<accessToken> {
     const authUser = await this.prismaService.auth.findUnique({
@@ -22,7 +25,9 @@ export class AuthService {
     });
 
     if (authUser) {
-      return { jwt: await this.generateJwt(authUser.userId, authUser.user.username)};
+      return {
+        jwt: await this.generateJwt(authUser.userId, authUser.user.username),
+      };
     }
 
     const createdUser = await this.prismaService.user.create({
@@ -39,7 +44,9 @@ export class AuthService {
         },
       },
     });
-    return { jwt: await this.generateJwt(createdUser.id, createdUser.username)};
+    return {
+      jwt: await this.generateJwt(createdUser.id, createdUser.username),
+    };
   }
 
   async generateJwt(id: string, username: string): Promise<string> {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-
+import { accessToken } from './types/auth.types';
 @Injectable()
 export class AuthService {
-  ftLogin() {
+  ftLogin(): accessToken {
     const mockJwt = 'mockJwt';
-    return mockJwt;
+    return { jwt: mockJwt };
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,26 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { accessToken } from './types/auth.types';
 import { JwtService } from '@nestjs/jwt';
+
 import { PrismaService } from '../prisma/prisma.service';
+
+import { authLoginDto } from './dto/auth.dto';
+
 @Injectable()
 export class AuthService {
   constructor(private readonly jwtService: JwtService, private readonly prismaService:PrismaService) {}
 
-  async ftLogin(): Promise<accessToken> {
-
-    const mockAuthLoginDto = {
-      email: 'mockEmail@example.com',
-      mockHashedPassword: 'mockHashedPassword',
-      providerId: 'mockSub',
-      providerName: '42',
-    };
-
+  async ftLogin(dto: authLoginDto): Promise<accessToken> {
     const authUser = await this.prismaService.auth.findUnique({
       include: { user: true },
       where: {
         providerName_providerId: {
-          providerId: mockAuthLoginDto.providerId,
-          providerName: mockAuthLoginDto.providerName,
+          providerId: dto.providerId,
+          providerName: dto.providerName,
         },
       },
     });
@@ -32,13 +28,13 @@ export class AuthService {
     const createdUser = await this.prismaService.user.create({
       include: { auth: true },
       data: {
-        email: mockAuthLoginDto.email,
+        email: dto.email,
         // TODO hashedPassword? にしたら消す
-        hashedPassword: mockAuthLoginDto.mockHashedPassword,
+        hashedPassword: 'mockHashedPassword',
         auth: {
           create: {
-            providerId: mockAuthLoginDto.providerId,
-            providerName: mockAuthLoginDto.providerName,
+            providerId: dto.providerId,
+            providerName: dto.providerName,
           },
         },
       },

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -1,0 +1,5 @@
+export class authLoginDto {
+  email: string;
+  providerId: string;
+  providerName: string;
+}

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty } from '@nestjs/swagger';
 export class authLoginDto {
   @ApiProperty({ example: 'hoge@example.com', description: 'test' })
   email: string;

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -1,5 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
 export class authLoginDto {
+  @ApiProperty({ example: 'hoge@example.com', description: 'test' })
   email: string;
+  @ApiProperty({ example: 'ft12345', description: 'test' })
   providerId: string;
+  @ApiProperty({ example: '42', description: 'test' })
   providerName: string;
 }

--- a/backend/src/auth/types/auth.types.ts
+++ b/backend/src/auth/types/auth.types.ts
@@ -1,0 +1,3 @@
+export type accessToken = {
+  jwt: string;
+};


### PR DESCRIPTION
jwtをuserid,usernameから作ってレスポンスbodyに入れて返すようにした
既にuser登録されてたらそいつを返す、いなかったらcreateして返す

jwtの作ってくれるやつ
https://www.npmjs.com/package/@nestjs/jwt




動的module
https://github.com/s-xix98/trc-prot/blob/6051728d9be355667aa97a7c8ccfc877099103cc/backend/src/auth/auth.module.ts#L11-L17
動的moduleの説明日本語
https://zenn.dev/kisihara_c/books/nest-officialdoc-jp/viewer/fundamentals-dynamicmodules#%E8%A8%AD%E5%AE%9A%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%AE%E4%BE%8B
