### PR TITLE
指定したケースで、コンポーネントでは、スナップショットをとらないようにする

### DIFF
--- a/frontend/.storybook/test-runner.js
+++ b/frontend/.storybook/test-runner.js
@@ -11,6 +11,16 @@ module.exports = {
   async postRender(page, context) {
     // If you want to take screenshot of multiple browsers, use
     // page.context().browser().browserType().name() to get the browser name to prefix the file name
+
+    // `SkipSnapshotTest` の文字列が含まれている場合、スナップショットのテストをスキップ
+    // name が パスカルケースのとき、間にスペースを入れてくる
+    // (SkipSnapshotTest -> `Skip Snapshot Test`)
+    // ので `Skip Snapshot Test` にしている
+    if (context.name.includes('Skip Snapshot Test')) {
+      console.log('Skip Snapshot Test :', context.name);
+      return;
+    }
+
     const image = await page.screenshot();
     expect(image).toMatchImageSnapshot({
       customSnapshotIdentifier: context.id,


### PR DESCRIPTION
- 指定したケースで、コンポーネントでは、スナップショットをとらないようにした
  - 動きのあるコンポーネントでdiff発生してテスト落ちるので
- storybook
  - 無効化したいケースは `SkipSnapshotTest` の文字列を含める
  - `export const Basic: Story = {};` -> `export const BasicSkipSnapshotTest: Story = {};`
