### PR TITLE
findの不要なオプションを削除

### DIFF
--- a/frontend/scripts/check_storybook_file.sh
+++ b/frontend/scripts/check_storybook_file.sh
@@ -1,5 +1,5 @@
 set -e
 
-for file in $(find src -type f -name '*.tsx' ! -name '*.stories.tsx' ! -name './src/lib/*' ! -path 'src/lib/*'| grep -v -e 'src/stories' -e 'main\.tsx'); do
+for file in $(find src -type f -name '*.tsx' ! -name '*.stories.tsx' ! -path 'src/lib/*' | grep -v -e 'src/stories' -e 'main\.tsx'); do
 	echo ${file} && test -f ${file%.tsx}.stories.tsx
 done


### PR DESCRIPTION
nameオプションは"/"を含むとマッチしないので、まったく意味がないから削除