### PR TITLE
nodeのバージョンを18にした

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:18
 
 WORKDIR /workdir
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # TODO: node２０のバグを修正したら消す
 # https://github.com/nodejs/node/issues/47822
-FROM node:19.9.0
+FROM node:18
 
 WORKDIR /workdir
 


### PR DESCRIPTION
node19は長期サポートじゃない
node20は現在ライブラリをnode20に合わせる期間でバグが多いらしい
なら１８だよね
https://nodejs.dev/en/about/releases/