### PR TITLE
326 auth用のテーブルを作る

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,6 +24,21 @@ model User {
   userProfile    UserProfile?
   friendship1    Friendship[]    @relation("src")
   friendship2    Friendship[]    @relation("dest")
+  auth           Auth?
+}
+
+model Auth {
+  userId String @unique
+  providerId String
+  providerName String
+  authProvider AuthProvider @relation(fields: [providerName], references: [name])
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@unique([providerName, providerId])
+}
+
+model AuthProvider {
+  name String @unique
+  auth Auth[]
 }
 
 // 今のところ画像のみ

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,24 @@ import { UserRole } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
+  const authProvider1 = await prisma.authProvider.upsert({
+    where: {
+      name: '42',
+    },
+    update: {},
+    create: {
+      name: '42',
+    },
+  });
+  const authProvider2 = await prisma.authProvider.upsert({
+    where: {
+      name: 'google',
+    },
+    update: {},
+    create: {
+      name: 'google',
+    },
+  });
   const user1 = await prisma.user.upsert({
     where: {
       email: 'huga@example.com',
@@ -57,6 +75,7 @@ async function main() {
       chatRoomId: room.id,
     },
   });
+  console.log(authProvider1, authProvider2);
   console.log(user1, user2);
   console.log(room, roomMember1, roomMember2);
 }


### PR DESCRIPTION
authでログインしたユーザーの情報を保存するテーブルを作った

アクセストークンでとってくるidとprovider名の組み合わせでuniqueとして判定するようにした

providerテーブルはテーブルで管理できるようにした
providerを増やしてもレコード挿入とfrontの変更だけで済む
現在42とgoogleを使ってるのでseedで入れた