### PR TITLE
buildでエラーが出てたのでdockerimage osのバージョンを変更した

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18-bullseye
 
 WORKDIR /workdir
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # TODO: node２０のバグを修正したら消す
 # https://github.com/nodejs/node/issues/47822
-FROM node:18
+FROM node:18-bullseye
 
 WORKDIR /workdir
 


### PR DESCRIPTION
debianの最新バージョン 12 がリリースされた
https://www.debian.org/News/2023/20230610
from node:18はdebianの最新バージョンになる
playwrightがdebian 12のサポートしてなくてビルドに失敗した
debian12 -> 11に変更した