### PR TITLE
宇宙の法則に従うことにした

### DIFF
--- a/backend/src/game/logic/game-logic.ts
+++ b/backend/src/game/logic/game-logic.ts
@@ -6,9 +6,9 @@ import { GameDto } from '../dto/GameDto';
 
 import { keyActions, Keys } from './KeyAction';
 
-const IsInRange = (pos: number, start: number, end: number) => {
-  return start < pos && pos < end;
-};
+// const IsInRange = (pos: number, start: number, end: number) => {
+//   return start < pos && pos < end;
+// };
 
 export class GameLogic {
   private ball: Ball;
@@ -60,6 +60,7 @@ export class GameLogic {
   }
 
   private UpdateBallPosition() {
+    // eslint-disable-next-line
     let newX = this.ball.x + this.ball.dx;
     let newY = this.ball.y + this.ball.dy;
 

--- a/backend/src/game/logic/game-logic.ts
+++ b/backend/src/game/logic/game-logic.ts
@@ -60,11 +60,18 @@ export class GameLogic {
   }
 
   private UpdateBallPosition() {
-    if (!IsInRange(this.ball.y + this.ball.dy, 0, 1)) {
+    let newX = this.ball.x + this.ball.dx;
+    let newY = this.ball.y + this.ball.dy;
+
+    if (newY <= 0) {
+      newY = -newY;
+      this.ball.dy = -this.ball.dy;
+    } else if (newY >= 1) {
+      newY = 1 - (newY - 1);
       this.ball.dy = -this.ball.dy;
     }
-    this.ball.x += this.ball.dx;
-    this.ball.y += this.ball.dy;
+    this.ball.x = newX;
+    this.ball.y = newY;
   }
 
   private HandleKeyActions() {


### PR DESCRIPTION
- [x] #537 から

衝突時に速度反転させてただけだったのを少し真面目に計算するようにした
今までは現フレームでのボール位置を起点に逆方向に座標移動させてただけ
ちゃんと衝突位置を起点に、残りの移動距離を動かすように変更した

例えば、速度が1Fに画面半分で、今ボールの位置が画面中心、向きが真上だとしたら
- 前　上の壁の衝突判定が発生して速度が反転、**ボールの位置**から計算して画面半分を下に移動 -> 下の壁あたりに移動
- 今　上の壁の衝突判定が発生して速度が反転、画面半分上に進んで、残り移動距離が0で、上の壁あたりで終わり
