### PR TITLE
695 [Game] プレイヤーの左右を表示

### DIFF
--- a/backend/src/game/logic/game-logic.ts
+++ b/backend/src/game/logic/game-logic.ts
@@ -61,7 +61,9 @@ export class GameLogic {
       this.p2.isReady = true;
     }
     if (this.p1.isReady && this.p2.isReady) {
-      this.StartGame();
+      this.p1.socket.emit('game ready left', this.ConvertToGameDto());
+      this.p2.socket.emit('game ready right', this.ConvertToGameDto());
+      setTimeout(this.StartGame.bind(this), 5000);
     }
   }
 

--- a/frontend/src/features/game/Game.tsx
+++ b/frontend/src/features/game/Game.tsx
@@ -103,6 +103,22 @@ const DrawResult = (
   ctx.fillText(result, (canvasWidth - width) / 2, canvasHeight / 2);
 };
 
+const DrawPlayerSide = (
+  ctx: CanvasRenderingContext2D,
+  side: 'LEFT' | 'RIGHT',
+  canvasWidth: number,
+  canvasHeight: number,
+  ) => {
+  ctx.fillStyle = 'white';
+  ctx.font = '30px serif'; // TODO ピクセル数動的に変わるべきかも
+  const width = ctx.measureText('YOU →').width;
+  if (side == 'LEFT') {
+    ctx.fillText('← YOU', canvasWidth / 4 - width / 2, canvasHeight / 2);
+  } else {
+    ctx.fillText('YOU →', (canvasWidth * 3) / 4 - width / 2, canvasHeight / 2);
+  }
+};
+
 const DrawCenterLine = (
   ctx: CanvasRenderingContext2D,
   canvasWidth: number,

--- a/frontend/src/features/game/Game.tsx
+++ b/frontend/src/features/game/Game.tsx
@@ -108,7 +108,7 @@ const DrawPlayerSide = (
   side: 'LEFT' | 'RIGHT',
   canvasWidth: number,
   canvasHeight: number,
-  ) => {
+) => {
   ctx.fillStyle = 'white';
   ctx.font = '30px serif'; // TODO ピクセル数動的に変わるべきかも
   const width = ctx.measureText('YOU →').width;
@@ -143,6 +143,29 @@ const GameCanvas = () => {
   const canvasWidth = 400;
   const canvasHeight = 400;
   const canvasId = 'canvas';
+
+  const ReadyGame = (gameDto: GameDto, side: 'LEFT' | 'RIGHT') => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) {
+      return;
+    }
+    const game = CreateGameObjects(gameDto, canvasWidth, canvasHeight);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    DrawCenterLine(ctx, canvas.width, canvas.height);
+    DrawScores(ctx, game.scores, canvas.width, canvas.height);
+    DrawPaddle(ctx, game.rightPaddle);
+    DrawPaddle(ctx, game.leftPaddle);
+    DrawPlayerSide(ctx, side, canvas.width, canvas.height);
+  };
+
+  useSocket('game ready left', (gameDto: GameDto) => {
+    ReadyGame(gameDto, 'LEFT');
+  });
+
+  useSocket('game ready right', (gameDto: GameDto) => {
+    ReadyGame(gameDto, 'RIGHT');
+  });
 
   useSocket('game data', (gameDto: GameDto) => {
     const canvas = canvasRef.current;


### PR DESCRIPTION
- [x] #697 から
- 自分がどっちのパドル操作するかバックエンドから通知されるようにした
  - バックとフロント共通の何かを定義するのがめんどかったのと、条件分岐増えるから、イベントリスナで分けたけど、データの送り方で分けた方がいいか？
- 表示は適当 